### PR TITLE
net: gptp: fix comparsion of stepsRemoved

### DIFF
--- a/subsys/net/l2/ethernet/gptp/gptp_mi.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.c
@@ -1662,7 +1662,7 @@ static int compute_best_vector(void)
 			}
 
 			tmp = (int)challenger->steps_removed -
-				((int)ntohs(best_vector->steps_removed) + 1);
+				(int)ntohs(best_vector->steps_removed);
 			if (tmp < 0) {
 				best_vector = challenger;
 				best_port = port;


### PR DESCRIPTION
The original implementation select the port
as best_port when stepsRemoved is equal to
the one of best_vector.