### PR TITLE
net: gptp: add missing stepsRemoved assignment

### DIFF
--- a/subsys/net/l2/ethernet/gptp/gptp_mi.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.c
@@ -1747,6 +1747,7 @@ static void update_bmca(int port,
 		bmca_data->master_priority.port_number = htons(port);
 		bmca_data->master_priority.src_port_id.port_number =
 			htons(port);
+		bmca_data->master_priority.steps_removed = gm_prio->steps_removed;
 	}
 
 	switch (bmca_data->info_is) {


### PR DESCRIPTION
The stepsRemoved of masterPriorityVector was
left unassigned when the best_port is not itself.